### PR TITLE
Add templates directory for RPI deployment

### DIFF
--- a/templates/single-spark/docker-compose.yml
+++ b/templates/single-spark/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+services:
+
+  eventbus:
+    image: rabbitmq:latest
+
+  influx:
+    image: hypriot/rpi-influxdb:latest
+    volumes:
+    - "./influxdb:/var/lib/influxdb"
+
+  history:
+    image: brewblox/brewblox-history:rpi-latest
+    depends_on:
+      - influx
+      - eventbus
+    labels:
+      - "traefik.port=5000"
+      - "traefik.frontend.rule=PathPrefix: /history"
+
+  spark:
+    image: brewblox/brewblox-devcon-spark:rpi-latest
+    privileged: true
+    depends_on:
+      - eventbus
+    labels:
+      - "traefik.port=5000"
+      - "traefik.frontend.rule=PathPrefix: /spark"
+    volumes:
+      - ./brewblox_db.json:/app/brewblox_db.json
+    command:
+      - "--database=/app/brewblox_db.json"
+      - "--unit-system-file=config/celsius_system.txt"
+
+  traefik:
+    image: traefik
+    command: -c /dev/null --api --docker --docker.domain=docker.localhost
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/templates/startup/README.md
+++ b/templates/startup/README.md
@@ -1,0 +1,19 @@
+# Running Docker Compose UI on startup in Raspberry
+
+Source: https://raspberrypi.stackexchange.com/questions/78991/running-a-script-after-an-internet-connection-is-established
+
+## Installation
+
+* Copy files in this directory to `~/startup/` on the Raspberry Pi
+* In the `startup/` directory, run `configure_service.sh`
+* Reboot the Raspberry Pi
+
+## SSH commands
+
+Run these commands from the current directory.
+Replace `raspberrypi` with its actual IP address.
+
+```
+scp -r . pi@raspberrypi:~/ && \
+ssh pi@raspberrypi "cd startup && bash configure_service.sh && sudo reboot"
+```

--- a/templates/startup/compose_ui.service
+++ b/templates/startup/compose_ui.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Compose UI service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/startup
+ExecStart=/bin/bash ./startup.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/startup/configure_service.sh
+++ b/templates/startup/configure_service.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+sudo chown pi ./startup.sh
+sudo chmod +x ./startup.sh
+
+sudo cp ./compose_ui.service /etc/systemd/system/
+sudo systemctl enable compose_ui.service
+sudo systemctl start compose_ui.service

--- a/templates/startup/startup.sh
+++ b/templates/startup/startup.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+docker run \
+    --rm \
+    --detach \
+    --name docker-compose-ui \
+    --volume /home/${USER}:/home/${USER} \
+    --workdir /home/${USER} \
+    --publish 5000:5000 \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    brewblox/docker-compose-ui


### PR DESCRIPTION
Resolves #9 

For now, only includes the startup scripts for the docker compose UI, and a setup for a single spark.

The contents of `templates/` should be copied to `/home/pi/`