### PR TITLE
Feature/spark integration tests

### DIFF
--- a/integration/Pipfile.lock
+++ b/integration/Pipfile.lock
@@ -18,46 +18,53 @@
     "default": {
         "aiohttp": {
             "hashes": [
-                "sha256:1a3cee4cd10de0ce6c37d7a35f437baa70ca87272a0ccd3d3e1a0383de2f189a",
-                "sha256:25983293a073ae530bd4027fb82a9f16fcfe48335873582946d2dc3ed64337f0",
-                "sha256:33630a2dc90fee1e05bd1b57cde51d65b571c61494a1a91772c8bc0896acb5c8",
-                "sha256:390c1a2c7799519b3755a6e3f660842c3b1544e92a10ecd309ea97ce5c8c713d",
-                "sha256:52fcb205ab8a43ddaf182c928f84e998a02213139b2b2636a26249569d9518bd",
-                "sha256:5c5de2bc5004c2c60e5f256978ad711c1fb4dca00890ac7884ed92c6aa520608",
-                "sha256:65b61cec34628c5a2e047f93555d93c29f4e29169839b421f62206b9f317f7ae",
-                "sha256:98f0172f7760597b636431b7651f020b8dba6a816b2d7e263afa54a4f2f4d0a6",
-                "sha256:9fcef0489e3335b200d31a9c1fb6ba80fdafe14cd82b971168c2f9fa1e4508ad",
-                "sha256:aeb5f0ef22896122fa5a84bf37202d3f6ee2404f12176608259bc408509f4883",
-                "sha256:b03578ad3f5ba6fa8b8614bd3628c4c33de92bd23af95ebd8f4de66bac35d3d8",
-                "sha256:bc50ec0dd5887844653ce5d2dd5dab93fd2e2af44d4be65d6d5306fb4039f2bf",
-                "sha256:c7a55a2bf7433ddf753ed46cf5a733c787524a41b933799541075dd8db9ead1b",
-                "sha256:f883507d537a838d496755a14a41f2c34c7af5f39d7627e15d6b2a27578705b7",
-                "sha256:feb271ced50b689b2e4d969a5bfb0a1cfd0cc05dd11cdde4e42d93e009e0b900"
+                "sha256:1a112a1fdf3802b7f2b182e22e51d71e4a8fa7387d0d38e79a268921b869e384",
+                "sha256:33aa7c937ebaf063a860cbb0c263a771b33333a84965c6148eeafe64fb4e29ca",
+                "sha256:550b4a0788500f6d00f41b7fdd9fcce6d78f99706a7b2f6f81d4d331c7ca468e",
+                "sha256:601e8e83123b4d423a9dfddf7d6943f4f520651a78ffcd50c99d065136c7ff7b",
+                "sha256:620f19ba7628b70b177f5c2e6a55a6fd6e7c8591cde38c3f8f52551733d31b66",
+                "sha256:70d56c784da1239c89d39fefa166fd429306dada641178389be4184a9c04e501",
+                "sha256:7de2c9e445a5d257935011268202338538abef1aaff341a4733eca56419ca6f6",
+                "sha256:96bb80b659cc2bafa160f3f0c346ce7fc10de1ffec4908d7f9690797f155f658",
+                "sha256:ae7501cc6a6c37b8d4774bf2218c37be47fe42019a2570e8510fc2044e59d573",
+                "sha256:c833aa6f4c9ac3e3eb843e3d999bae51339ad33a937303f43ce78064e61cb4b6",
+                "sha256:dd81d85a342edf3d2a388e2f24d9facebc9c04550043888f970ee2f228c93059",
+                "sha256:f20deec7a3fbaec7b5eb7ad99878427ad2ee4cc16a46732b705e8121cbb3cc12",
+                "sha256:f52e7287eb9286a1e91e4c67c207c2573147fbaddc68f70efb5aeee5d1992f2e",
+                "sha256:fe7b2972ff7e779e812f974aa5695edc328ecf559ceeea887ac46f06f090ad4c",
+                "sha256:ff1447c84a02b9cd5dd3a9332d1fb181a4386c3625765bb5caf1cfbc210ab3f9"
             ],
             "index": "pypi",
-            "version": "==3.1.3"
+            "version": "==3.3.2"
         },
         "async-timeout": {
             "hashes": [
-                "sha256:00cff4d2dce744607335cba84e9929c3165632da2d27970dbc55802a0c7873d0",
-                "sha256:9093db5b8ddbe4b8f6885d1a6e0ad84ae3155464cbf6877c387605244c285f3c"
+                "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
+                "sha256:b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287"
             ],
-            "version": "==2.0.1"
+            "version": "==3.0.0"
         },
         "asynctest": {
             "hashes": [
-                "sha256:92e92d3d31c5a684e1f4f9f3fcd8c4c7a3e40b380e4164d8f49a362c7f402b95",
-                "sha256:c01915e9c83873ad6af42d078b67e8f9e16122f966f57053e5320d8c5ad135aa"
+                "sha256:56bd75b03df55956d57437db26700503d1013616314db5d1ea1a73be1186fd71",
+                "sha256:77520850ae21620ec31738f4a7b467acaa44de6d3752d8ac7a9f4dcf55d77853"
             ],
             "index": "pypi",
-            "version": "==0.12.0"
+            "version": "==0.12.2"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
         },
         "attrs": {
             "hashes": [
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
-            "version": "==17.4.0"
+            "version": "==18.1.0"
         },
         "chardet": {
             "hashes": [
@@ -82,16 +89,16 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "idna-ssl": {
             "hashes": [
-                "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.0"
         },
         "mccabe": {
             "hashes": [
@@ -102,38 +109,29 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
-                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
-                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
             ],
-            "version": "==4.1.0"
+            "version": "==4.2.0"
         },
         "multidict": {
             "hashes": [
-                "sha256:0dcf4f2893bf22839c7bd825f688d5fe60c8eb989b4eb817103a71d7f84058e5",
-                "sha256:1524bb334b605f6c7cf447e19e70d6fb96f68aefefe018bdceb9674572548c45",
-                "sha256:1b93d1b72b12566a6e238acb4f547cdf6de069c5b555faabfe9071852434b61a",
-                "sha256:24052724195e46872739faa10c611957bbaceae28eec92e1ce49150b115ec5ed",
-                "sha256:27643705c5a04cfbf7834b914e5367618f77b2692f920c734b18f476ea328f04",
-                "sha256:2b07135edc953e6a7e94d8628868715093efb015fc6a0ebf54c5ecd84064e5f8",
-                "sha256:3876b617228d60d655062f9ddaecb0f770777b8ae753e661de9a7d5eb4ef2933",
-                "sha256:3f11e31935d20822c977397e9ec868ab2287c82461bc74663c7df1bd8a5b61d0",
-                "sha256:4e0dbf5a204c462d6b129b9598e5124077244a9b91c255c5341f679472dc54a5",
-                "sha256:5a56ec27a528fce6a3fdf537929b039b8af01edec761b09f7fcde3915d3fbbe7",
-                "sha256:5bd46d01a49264f059d4c7b1f26cb5cbbcacb549edb77ad5caa2070ec4bffe47",
-                "sha256:6e5128658f82cd8d1830f159027c2be0af496b1b6aa710353a6c862a9285bc89",
-                "sha256:6ef4cf27db3424bcc6e7f9ead3abee53bca2c3a1db5821585cb3e386ae55178f",
-                "sha256:7aeccfbc7ccc29dcceca11ee295f5a267b093d90cf50808d4649d87e72bdbd89",
-                "sha256:7c43ca71db568e13d301e3a6153996a3e0da5d4b19c3517d2418fa5775d2d173",
-                "sha256:9deae50f23511e5639fadf8df68917027535e090b163c5bbb03e26f6a208dbfc",
-                "sha256:aab8e9063ff623387f72c04b55c43211da2edd4e0db9943057522a995c330877",
-                "sha256:ae1002b4c793a6b88c8208c8a312038185ffcf76a57fdbe6c5d0f62052737a65",
-                "sha256:af340843de65c4d678379e8e0b5bcfd2e614da8ed666f1ba006704fe456edbba",
-                "sha256:d3161a3697f8a332aa86da1402f4020499d50ccedc6eb3d8a40d5e3aca3c2afd",
-                "sha256:eafe84d62e45b17c82483a6b4b1a9757c91a1d6d9511d8b32ded52936582fdcb",
-                "sha256:f16c517bb33c8ce75ba5e8d5212e3591bc59f4ab837b5b9906a3ee5868180449"
+                "sha256:1a1d76374a1e7fe93acef96b354a03c1d7f83e7512e225a527d283da0d7ba5e0",
+                "sha256:1d6e191965505652f194bc4c40270a842922685918a4f45e6936a6b15cc5816d",
+                "sha256:295961a6a88f1199e19968e15d9b42f3a191c89ec13034dbc212bf9c394c3c82",
+                "sha256:2be5af084de6c3b8e20d6421cb0346378a9c867dcf7c86030d6b0b550f9888e4",
+                "sha256:2eb99617c7a0e9f2b90b64bc1fb742611718618572747d6f3d6532b7b78755ab",
+                "sha256:4ba654c6b5ad1ae4a4d792abeb695b29ce981bb0f157a41d0fd227b385f2bef0",
+                "sha256:5ba766433c30d703f6b2c17eb0b6826c6f898e5f58d89373e235f07764952314",
+                "sha256:a59d58ee85b11f337b54933e8d758b2356fcdcc493248e004c9c5e5d11eedbe4",
+                "sha256:a6e35d28900cf87bcc11e6ca9e474db0099b78f0be0a41d95bef02d49101b5b2",
+                "sha256:b4df7ca9c01018a51e43937eaa41f2f5dce17a6382fda0086403bcb1f5c2cf8e",
+                "sha256:bbd5a6bffd3ba8bfe75b16b5e28af15265538e8be011b0b9fddc7d86a453fd4a",
+                "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
+                "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.1"
         },
         "nesdict": {
             "hashes": [
@@ -159,15 +157,13 @@
         },
         "py": {
             "hashes": [
-                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
-                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "version": "==1.5.3"
+            "version": "==1.5.4"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
-                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],
@@ -182,10 +178,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
-                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
+                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
+                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
             ],
-            "version": "==3.5.1"
+            "version": "==3.6.3"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -197,19 +193,19 @@
         },
         "pytest-flake8": {
             "hashes": [
-                "sha256:3996de65a1219697596acac755090c70c47ec901edc438ea88ce1aa6098fb905",
-                "sha256:43598dfa211242525897866ff35fa553ebd88177383783079099057c7ad04331"
+                "sha256:e5cdc4f459c9436ac6c649e428a014bb5988605858549397374ec29a776cae68",
+                "sha256:ec248d4a215d6c7cd9d3ca48f365ece0e3892b46d626c22a95ccc80188ff35ed"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:173fd47c872d105368aeb22dca1415db9f269c0ee1c3832c3aebadd3e80f6133",
-                "sha256:40f4f7148a81c94656a4fe7cf067edd62e541599bb70a6d3af50ffac4c2312f2"
+                "sha256:53801e621223d34724926a5c98bd90e8e417ce35264365d39d6c896388dcc928",
+                "sha256:d89a8209d722b8307b5e351496830d5cc5e192336003a485443ae9adeb7dd4c0"
             ],
             "index": "pypi",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pytest-sugar": {
             "hashes": [
@@ -233,21 +229,17 @@
         },
         "yarl": {
             "hashes": [
-                "sha256:045dbba18c9142278113d5dc62622978a6f718ba662392d406141c59b540c514",
-                "sha256:17e57a495efea42bcfca08b49e16c6d89e003acd54c99c903ea1cb3de0ba1248",
-                "sha256:213e8f54b4a942532d6ac32314c69a147d3b82fa1725ca05061b7c1a19a1d9b1",
-                "sha256:3353fae45d93cc3e7e41bfcb1b633acc37db821d368e660b03068dbfcf68f8c8",
-                "sha256:51a084ff8756811101f8b5031a14d1c2dd26c666976e1b18579c6b1c8761a102",
-                "sha256:5580f22ac1298261cd24e8e584180d83e2cca9a6167113466d2d16cb2aa1f7b1",
-                "sha256:64727a2593fdba5d6ef69e94eba793a196deeda7152c7bd3a64edda6b1f95f6e",
-                "sha256:6e75753065c310befab71c5077a59b7cb638d2146b1cfbb1c3b8f08b51362714",
-                "sha256:7236eba4911a5556b497235828e7a4bc5d90957efa63b7c4b3e744d2d2cf1b94",
-                "sha256:a69dd7e262cdb265ac7d5e929d55f2f3d07baaadd158c8f19caebf8dde08dfe8",
-                "sha256:d9ca55a5a297408f08e5401c23ad22bd9f580dab899212f0d5dc1830f0909404",
-                "sha256:e072edbd1c5628c0b8f97d00cf6c9fcd6a4ee2b5ded10d463fcb6eaa066cf40c",
-                "sha256:e9a6a319c4bbfb57618f207e86a7c519ab0f637be3d2366e4cdac271577834b8"
+                "sha256:2556b779125621b311844a072e0ed367e8409a18fa12cbd68eb1258d187820f9",
+                "sha256:4aec0769f1799a9d4496827292c02a7b1f75c0bab56ab2b60dd94ebb57cbd5ee",
+                "sha256:55369d95afaacf2fa6b49c84d18b51f1704a6560c432a0f9a1aeb23f7b971308",
+                "sha256:6c098b85442c8fe3303e708bbb775afd0f6b29f77612e8892627bcab4b939357",
+                "sha256:9182cd6f93412d32e009020a44d6d170d2093646464a88aeec2aef50592f8c78",
+                "sha256:c8cbc21bbfa1dd7d5386d48cc814fe3d35b80f60299cdde9279046f399c3b0d8",
+                "sha256:db6f70a4b09cde813a4807843abaaa60f3b15fb4a2a06f9ae9c311472662daa1",
+                "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
+                "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
             ],
-            "version": "==1.1.1"
+            "version": "==1.2.6"
         }
     },
     "develop": {}

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -32,6 +32,19 @@ services:
     command:
       - "--name=publisher"
 
+  spark:
+    image: brewblox/brewblox-devcon-spark:develop
+    privileged: true
+    depends_on:
+      - eventbus
+    labels:
+      - "traefik.port=5000"
+      - "traefik.frontend.rule=PathPrefix: /spark"
+    command:
+      - "--simulation"
+      - "--broadcast-interval=1"
+      - "--unit-system-file=/app/config/celsius_system.txt"
+
   traefik:
     image: traefik
     command: -c /dev/null --api --docker --docker.domain=docker.localhost --logLevel=DEBUG

--- a/integration/test/conftest.py
+++ b/integration/test/conftest.py
@@ -1,11 +1,10 @@
 import asyncio
 import logging
+from subprocess import STDOUT, call
 
 import aiohttp
 import pytest
 from async_timeout import timeout
-
-from subprocess import call, STDOUT
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -32,7 +31,8 @@ def host():
 def services():
     return [
         'history',
-        'publisher'
+        'publisher',
+        'spark',
     ]
 
 

--- a/integration/test/test_spark.py
+++ b/integration/test/test_spark.py
@@ -2,6 +2,7 @@
 Tests the brewblox-devcon-spark service
 """
 
+import asyncio
 
 import pytest
 from aiohttp.client_exceptions import ClientResponseError
@@ -112,3 +113,21 @@ async def test_write_system(session, host):
     print(retd)
 
     assert 'cc' in retd['data']['address']
+
+
+@pytest.mark.asyncio
+async def test_broadcast(session, host):
+    # Sleep to ensure broadcaster has sent something
+    await asyncio.sleep(2)
+
+    retv = await session.post(host + '/history/query/objects', json={})
+    retd = await retv.json()
+    print(retd)
+    assert 'sensey/settings/offset[delta_degC]' in retd['spark']
+
+    retv = await session.post(host + '/history/query/values', json={
+        'measurement': 'spark'
+    })
+    retd = await retv.json()
+    print(retd)
+    assert 'sensey/settings/offset[delta_degC]' in retd['columns']

--- a/integration/test/test_spark.py
+++ b/integration/test/test_spark.py
@@ -1,0 +1,114 @@
+"""
+Tests the brewblox-devcon-spark service
+"""
+
+
+import pytest
+from aiohttp.client_exceptions import ClientResponseError
+
+
+@pytest.fixture
+def sensey():
+    return {
+        'id': 'sensey',
+        'type': 'OneWireTempSensor',
+        'data': {
+            'settings': {
+                'address': 'FF',
+                'offset[delta_degF]': 20
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_objects(session, host, sensey):
+    create_url = host + '/spark/objects'
+    retv = await session.post(create_url, json=sensey)
+    retd = await retv.json()
+    print(retd)
+
+    assert retd['id'] == sensey['id']
+    assert retd['data']['settings']['offset[delta_degC]']
+
+    sensey['id'] = 'sensex'
+    await session.post(create_url, json=sensey)
+
+    with pytest.raises(ClientResponseError):
+        del sensey['id']
+        await session.post(create_url, json=sensey)
+
+
+@pytest.mark.asyncio
+async def test_read_objects(session, host, sensey):
+    retv = await session.get(host + '/spark/objects/sensey')
+    retd = await retv.json()
+    print(retd)
+
+    assert retd['id'] == 'sensey'
+    assert retd['data']['settings']['offset[delta_degC]']
+
+    await session.get(host + '/spark/objects/sensex')
+
+
+@pytest.mark.asyncio
+async def test_read_all(session, host):
+    retv = await session.get(host + '/spark/objects')
+    retd = await retv.json()
+
+    assert len(retd) == 2
+    assert retd[0]['id'] == 'sensey'
+    assert retd[1]['id'] == 'sensex'
+
+    assert retd[0]['type'] == 'OneWireTempSensor'
+
+
+@pytest.mark.asyncio
+async def test_write_object(session, host, sensey):
+    url = host + '/spark/objects/sensey'
+    del sensey['id']
+    sensey['data']['settings']['offset[delta_degF]'] = 30
+
+    await session.put(url, json=sensey)
+    retv = await session.get(url)
+    retd = await retv.json()
+
+    assert retd['data']['settings']['offset[delta_degC]'] == pytest.approx(16.7, 0.1)
+
+
+@pytest.mark.asyncio
+async def test_delete_object(session, host, sensey):
+    url = host + '/spark/objects'
+    sensey['id'] = 'sensey_del'
+
+    await session.post(url, json=sensey)
+    await session.get(url + '/sensey_del')
+    await session.delete(url + '/sensey_del')
+
+    with pytest.raises(ClientResponseError):
+        await session.get(url + '/sensey_del')
+
+
+@pytest.mark.asyncio
+async def test_read_system(session, host):
+    retv = await session.get(host + '/spark/system/onewirebus')
+    retd = await retv.json()
+    print(retd)
+
+    assert retd['data']['address']
+
+
+@pytest.mark.asyncio
+async def test_write_system(session, host):
+    retv = await session.get(host + '/spark/system/onewirebus')
+    retd = await retv.json()
+    print(retd)
+
+    retd['data']['address'].append('cc')
+    await session.put(host + '/spark/system/onewirebus', json=retd)
+
+    retv = await session.get(host + '/spark/system/onewirebus')
+    retd = await retv.json()
+    print(retd)
+
+    assert 'cc' in retd['data']['address']

--- a/templates/single-spark/docker-compose.yml
+++ b/templates/single-spark/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   influx:
     image: hypriot/rpi-influxdb:latest
     volumes:
-    - "./influxdb:/var/lib/influxdb"
+    - "./influxdb/:/var/lib/influxdb/"
 
   history:
     image: brewblox/brewblox-history:rpi-latest
@@ -18,9 +18,13 @@ services:
     labels:
       - "traefik.port=5000"
       - "traefik.frontend.rule=PathPrefix: /history"
+    volumes:
+      - ./logs/:/app/logs/
+    command:
+      - "--output=/app/logs/history.txt"
 
   spark:
-    image: brewblox/brewblox-devcon-spark:rpi-latest
+    image: brewblox/brewblox-devcon-spark:rpi-develop
     privileged: true
     depends_on:
       - eventbus
@@ -28,10 +32,12 @@ services:
       - "traefik.port=5000"
       - "traefik.frontend.rule=PathPrefix: /spark"
     volumes:
-      - ./brewblox_db.json:/app/brewblox_db.json
+      - ./logs/:/app/logs/
+      - ./brewblox/:/app/brewblox/
     command:
-      - "--database=/app/brewblox_db.json"
-      - "--unit-system-file=config/celsius_system.txt"
+      - "--output=/app/logs/history.txt"
+      - "--database=/app/brewblox/brewblox_db.json"
+      - "--unit-system-file=/app/config/celsius_system.txt"
 
   traefik:
     image: traefik

--- a/templates/single-spark/docker-compose.yml
+++ b/templates/single-spark/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+services:
+
+  eventbus:
+    image: rabbitmq:latest
+
+  influx:
+    image: hypriot/rpi-influxdb:latest
+    volumes:
+    - "./influxdb:/var/lib/influxdb"
+
+  history:
+    image: brewblox/brewblox-history:rpi-latest
+    depends_on:
+      - influx
+      - eventbus
+    labels:
+      - "traefik.port=5000"
+      - "traefik.frontend.rule=PathPrefix: /history"
+
+  spark:
+    image: brewblox/brewblox-devcon-spark:rpi-latest
+    privileged: true
+    depends_on:
+      - eventbus
+    labels:
+      - "traefik.port=5000"
+      - "traefik.frontend.rule=PathPrefix: /spark"
+    volumes:
+      - ./brewblox_db.json:/app/brewblox_db.json
+    command:
+      - "--database=/app/brewblox_db.json"
+      - "--unit-system-file=config/celsius_system.txt"
+
+  traefik:
+    image: traefik
+    command: -c /dev/null --api --docker --docker.domain=docker.localhost
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/templates/startup/README.md
+++ b/templates/startup/README.md
@@ -1,0 +1,19 @@
+# Running Docker Compose UI on startup in Raspberry
+
+Source: https://raspberrypi.stackexchange.com/questions/78991/running-a-script-after-an-internet-connection-is-established
+
+## Installation
+
+* Copy files in this directory to `~/startup/` on the Raspberry Pi
+* In the `startup/` directory, run `configure_service.sh`
+* Reboot the Raspberry Pi
+
+## SSH commands
+
+Run these commands from the current directory.
+Replace `raspberrypi` with its actual IP address.
+
+```
+scp -r . pi@raspberrypi:~/ && \
+ssh pi@raspberrypi "cd startup && bash configure_service.sh && sudo reboot"
+```

--- a/templates/startup/compose_ui.service
+++ b/templates/startup/compose_ui.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Compose UI service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/startup
+ExecStart=/bin/bash ./startup.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/startup/configure_service.sh
+++ b/templates/startup/configure_service.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+sudo chown pi ./startup.sh
+sudo chmod +x ./startup.sh
+
+sudo cp ./compose_ui.service /etc/systemd/system/
+sudo systemctl enable compose_ui.service
+sudo systemctl start compose_ui.service

--- a/templates/startup/startup.sh
+++ b/templates/startup/startup.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+docker run \
+    --rm \
+    --detach \
+    --name docker-compose-ui \
+    --volume /home/${USER}:/home/${USER} \
+    --workdir /home/${USER} \
+    --publish 5000:5000 \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    brewblox/docker-compose-ui


### PR DESCRIPTION
Add simple integration tests for Spark simulation CRUD.

Resolves #17 
Includes changes from #18 

Can only be merged after brewblox/brewblox-devcon-spark#40 as it depends on string object types.